### PR TITLE
DIV-5684: remove builder annotation as it caused error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '1.0.5'
+version '1.0.6'
 
 dependencyUpdates.resolutionStrategy = {
     componentSelection { rules ->

--- a/src/main/java/uk/gov/hmcts/reform/divorce/models/request/DocumentLink.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/models/request/DocumentLink.java
@@ -6,7 +6,6 @@ import lombok.Builder;
 import lombok.Data;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@Builder
 @Data
 public class DocumentLink {
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/models/request/DocumentLink.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/models/request/DocumentLink.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.divorce.models.request;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Builder;
 import lombok.Data;
 
 @JsonIgnoreProperties(ignoreUnknown = true)


### PR DESCRIPTION
This builder annotation caused error:

```
(through reference chain: uk.gov.hmcts.reform.divorce.models.request.CoreCaseData["D8DocumentsUploaded"]->java.util.ArrayList[0]->uk.gov.hmcts.reform.divorce.models.request.CollectionMember["value"]->uk.gov.hmcts.reform.divorce.models.request.Document["DocumentLink"])] with root cause
com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Cannot construct instance of `uk.gov.hmcts.reform.divorce.models.request.DocumentLink` (no Creators, like default construct, exist): cannot deserialize from Object value (no delegate- or property-based Creator)
 at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: uk.gov.hmcts.reform.divorce.models.request.CoreCaseData["D8DocumentsUploaded"]->java.util.ArrayList[0]->uk.gov.hmcts.reform.divorce.models.request.CollectionMember["value"]->uk.gov.hmcts.reform.divorce.models.request.Document["DocumentLink"])
        at com.fasterxml.jackson.databind.exc.InvalidDefinitionException.from(InvalidDefinitionException.java:67)
        at com.fasterxml.jackson.databind.DeserializationContext.reportBadDefinition(DeserializationContext.java:1452)
        at com.fasterxml.jackson.databind.DeserializationContext.handleMissingInstantiator(DeserializationContext.java:1028)
        at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1297)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:326)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:159)
        at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:129)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:288)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:151)
        at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:129)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:288)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:151)
        at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:28
```