### PR TITLE
DIV-5684: removed @Builder from models where it caused errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '1.0.6'
+version '1.0.7'
 
 dependencyUpdates.resolutionStrategy = {
     componentSelection { rules ->

--- a/src/main/java/uk/gov/hmcts/reform/divorce/models/request/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/models/request/Event.java
@@ -1,11 +1,9 @@
 package uk.gov.hmcts.reform.divorce.models.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Builder;
 import lombok.Data;
 
 @Data
-@Builder
 public class Event {
 
     @JsonProperty("id")

--- a/src/main/java/uk/gov/hmcts/reform/divorce/models/request/PaymentCollection.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/models/request/PaymentCollection.java
@@ -1,10 +1,8 @@
 package uk.gov.hmcts.reform.divorce.models.request;
 
-import lombok.Builder;
 import lombok.Data;
 
 @Data
-@Builder
 public class PaymentCollection {
 
     private String id;

--- a/src/main/java/uk/gov/hmcts/reform/divorce/models/request/UploadedFile.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/models/request/UploadedFile.java
@@ -2,13 +2,11 @@ package uk.gov.hmcts.reform.divorce.models.request;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import lombok.Builder;
 import lombok.Data;
 
 import java.util.Date;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@Builder
 @Data
 public class UploadedFile {
 


### PR DESCRIPTION
From logs:

```
2019-Aug-30 12:19:45.151 ERROR [http-nio-4012-exec-1] o.a.c.c.C.[.[.[.[dispatcherServlet] - Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed; nested exception is java.lang.IllegalArgumentException: Cannot construct instance of `uk.gov.hmcts.reform.divorce.models.request.PaymentCollection` (no Creators, like default construct, exist): cannot deserialize from Object value (no delegate- or property-based Creator)
 at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: uk.gov.hmcts.reform.divorce.models.request.CoreCaseData["Payments"]->java.util.ArrayList[0])] with root cause
com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Cannot construct instance of `uk.gov.hmcts.reform.divorce.models.request.PaymentCollection` (no Creators, like default construct, exist): cannot deserialize from Object value (no delegate- or property-based Creator)
 at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: uk.gov.hmcts.reform.divorce.models.request.CoreCaseData["Payments"]->java.util.ArrayList[0])
	at com.fasterxml.jackson.databind.exc.InvalidDefinitionException.from(InvalidDefinitionException.java:67)
	at com.fasterxml.jackson.databind.DeserializationContext.reportBadDefinition(DeserializationContext.java:1452)
	at com.fasterxml.jackson.databind.DeserializationContext.handleMissingInstantiator(DeserializationContext.java:1028)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1297)
```

Something like this is caused by `@Builder` annotation. It's not a problem when model is used by SpringBoot controllers to map JSON to model, but when you use Jackson `ObjectMapper` is not working.