### PR TITLE
Added DN Clarification Mapper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '1.1.0'
+version '1.1.1'
 
 dependencyUpdates.resolutionStrategy = {
     componentSelection { rules ->

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '1.0.10'
+version '1.1.0'
 
 dependencyUpdates.resolutionStrategy = {
     componentSelection { rules ->

--- a/src/main/java/uk/gov/hmcts/reform/divorce/formatter/mapper/CCDCaseToDivorceMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/formatter/mapper/CCDCaseToDivorceMapper.java
@@ -155,6 +155,8 @@ public abstract class CCDCaseToDivorceMapper {
         dateFormat = SIMPLE_DATE_FORMAT, target = "dateRespondentEligibleForDA")
     @Mapping(source = "dateCaseNoLongerEligibleForDA",
         dateFormat = SIMPLE_DATE_FORMAT, target = "dateCaseNoLongerEligibleForDA")
+    @Mapping(source = "refusalClarificationReason", target = "refusalClarificationReason")
+    @Mapping(source = "refusalClarificationAdditionalInfo", target = "refusalClarificationAdditionalInfo")
     public abstract DivorceSession courtCaseDataToDivorceCaseData(CoreCaseData coreCaseData);
 
     private String translateToBooleanString(final String value) {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/formatter/mapper/DivorceCaseToDnClarificationMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/formatter/mapper/DivorceCaseToDnClarificationMapper.java
@@ -1,0 +1,59 @@
+package uk.gov.hmcts.reform.divorce.formatter.mapper;
+
+import org.mapstruct.AfterMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.ReportingPolicy;
+
+import uk.gov.hmcts.reform.divorce.model.DivorceCaseWrapper;
+import uk.gov.hmcts.reform.divorce.model.ccd.CollectionMember;
+import uk.gov.hmcts.reform.divorce.model.ccd.DnCaseData;
+import uk.gov.hmcts.reform.divorce.model.ccd.Document;
+import uk.gov.hmcts.reform.divorce.model.usersession.DivorceSession;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Mapper(componentModel = "spring", uses = DocumentCollectionCCDFormatMapper.class,
+    unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public abstract class DivorceCaseToDnClarificationMapper {
+
+    @Mapping(source = "divorceSession.files", target = "documentsUploadedDnClarification")
+    public abstract DnCaseData divorceCaseDataToDnCaseData(DivorceCaseWrapper divorceCaseWrapper);
+
+    @AfterMapping
+    protected void mapDnClarificationResponse(DivorceCaseWrapper divorceCaseWrapper,
+                                              @MappingTarget DnCaseData result) {
+
+        List<String> clarificationReasons =
+            Optional.ofNullable(divorceCaseWrapper.getCaseData().getDnClarificationResponse())
+                .orElse(new ArrayList<>());
+
+        DivorceSession divorceSession = divorceCaseWrapper.getDivorceSession();
+
+        if (!divorceSession.getClarificationResponse().isEmpty()) {
+            clarificationReasons.add(divorceSession.getClarificationResponse());
+        }
+
+        result.setDnClarificationResponse(clarificationReasons);
+    }
+
+    @AfterMapping
+    protected void mapDocumentsUploadedDnClarification(DivorceCaseWrapper divorceCaseWrapper,
+                                                       @MappingTarget DnCaseData result) {
+
+        List<CollectionMember<Document>> clarificationDocuments =
+            Optional.ofNullable(divorceCaseWrapper.getCaseData().getDocumentsUploadedDnClarification())
+                .orElse(new ArrayList<>());
+
+        // New documents are already added to the result from the @Mapping annotation on the constructor
+        // This can then be used in the AfterMapping
+        if (!result.getDocumentsUploadedDnClarification().isEmpty()) {
+            clarificationDocuments.addAll(result.getDocumentsUploadedDnClarification());
+        }
+
+        result.setDocumentsUploadedDnClarification(clarificationDocuments);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/formatter/mapper/DivorceCaseToDnClarificationMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/formatter/mapper/DivorceCaseToDnClarificationMapper.java
@@ -27,14 +27,17 @@ public abstract class DivorceCaseToDnClarificationMapper {
     protected void mapDnClarificationResponse(DivorceCaseWrapper divorceCaseWrapper,
                                               @MappingTarget DnCaseData result) {
 
-        List<String> clarificationReasons =
+        List<CollectionMember<String>> clarificationReasons =
             Optional.ofNullable(divorceCaseWrapper.getCaseData().getDnClarificationResponse())
                 .orElse(new ArrayList<>());
 
         DivorceSession divorceSession = divorceCaseWrapper.getDivorceSession();
 
         if (!divorceSession.getClarificationResponse().isEmpty()) {
-            clarificationReasons.add(divorceSession.getClarificationResponse());
+            CollectionMember<String> clarificationResponse = new CollectionMember<>();
+            clarificationResponse.setValue(divorceSession.getClarificationResponse());
+
+            clarificationReasons.add(clarificationResponse);
         }
 
         result.setDnClarificationResponse(clarificationReasons);

--- a/src/main/java/uk/gov/hmcts/reform/divorce/formatter/service/CaseFormatterService.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/formatter/service/CaseFormatterService.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.divorce.formatter.service;
 
+import uk.gov.hmcts.reform.divorce.model.DivorceCaseWrapper;
 import uk.gov.hmcts.reform.divorce.model.ccd.AosCaseData;
 import uk.gov.hmcts.reform.divorce.model.ccd.CoreCaseData;
 import uk.gov.hmcts.reform.divorce.model.ccd.DaCaseData;
@@ -26,6 +27,8 @@ public interface CaseFormatterService {
     AosCaseData getAosCaseData(DivorceSession divorceSession);
 
     DnCaseData getDnCaseData(DivorceSession divorceSession);
+
+    DnCaseData getDnClarificationCaseData(DivorceCaseWrapper divorceCaseWrapper);
 
     DaCaseData getDaCaseData(DivorceSession divorceSession);
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/formatter/service/impl/CaseFormatterServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/formatter/service/impl/CaseFormatterServiceImpl.java
@@ -10,8 +10,10 @@ import uk.gov.hmcts.reform.divorce.formatter.mapper.DivorceCaseToAosCaseMapper;
 import uk.gov.hmcts.reform.divorce.formatter.mapper.DivorceCaseToCCDMapper;
 import uk.gov.hmcts.reform.divorce.formatter.mapper.DivorceCaseToDaCaseMapper;
 import uk.gov.hmcts.reform.divorce.formatter.mapper.DivorceCaseToDnCaseMapper;
+import uk.gov.hmcts.reform.divorce.formatter.mapper.DivorceCaseToDnClarificationMapper;
 import uk.gov.hmcts.reform.divorce.formatter.mapper.DocumentCollectionDocumentRequestMapper;
 import uk.gov.hmcts.reform.divorce.formatter.service.CaseFormatterService;
+import uk.gov.hmcts.reform.divorce.model.DivorceCaseWrapper;
 import uk.gov.hmcts.reform.divorce.model.ccd.AosCaseData;
 import uk.gov.hmcts.reform.divorce.model.ccd.CollectionMember;
 import uk.gov.hmcts.reform.divorce.model.ccd.CoreCaseData;
@@ -32,6 +34,7 @@ import static uk.gov.hmcts.reform.divorce.model.DocumentType.PETITION;
 public class CaseFormatterServiceImpl implements CaseFormatterService {
 
     private static final String D8_DOCUMENTS_GENERATED_CCD_FIELD = "D8DocumentsGenerated";
+    private static final String GENERIC_DOCUMENT_TYPE = "other";
 
     @Autowired
     private ObjectMapper objectMapper;
@@ -50,6 +53,9 @@ public class CaseFormatterServiceImpl implements CaseFormatterService {
 
     @Autowired
     private DivorceCaseToDnCaseMapper divorceCaseToDnCaseMapper;
+
+    @Autowired
+    private DivorceCaseToDnClarificationMapper divorceCaseToDnClarificationMapper;
 
     @Autowired
     private DivorceCaseToDaCaseMapper divorceCaseToDaCaseMapper;
@@ -88,7 +94,8 @@ public class CaseFormatterServiceImpl implements CaseFormatterService {
             if (CollectionUtils.isNotEmpty(documentsGenerated)) {
                 List<CollectionMember<Document>> existingDocuments = documentsGenerated.stream()
                     .filter(documentCollectionMember ->
-                        !generatedDocumentInfos.stream()
+                        GENERIC_DOCUMENT_TYPE.equals(documentCollectionMember.getValue().getDocumentType())
+                        || !generatedDocumentInfos.stream()
                             .map(GeneratedDocumentInfo::getDocumentType)
                             .collect(Collectors.toSet())
                             .contains(documentCollectionMember.getValue().getDocumentType()))
@@ -136,6 +143,11 @@ public class CaseFormatterServiceImpl implements CaseFormatterService {
     @Override
     public DnCaseData getDnCaseData(DivorceSession divorceSession) {
         return divorceCaseToDnCaseMapper.divorceCaseDataToDnCaseData(divorceSession);
+    }
+
+    @Override
+    public DnCaseData getDnClarificationCaseData(DivorceCaseWrapper divorceCaseWrapper) {
+        return divorceCaseToDnClarificationMapper.divorceCaseDataToDnCaseData(divorceCaseWrapper);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/divorce/model/DivorceCaseWrapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/model/DivorceCaseWrapper.java
@@ -1,0 +1,12 @@
+package uk.gov.hmcts.reform.divorce.model;
+
+import lombok.Value;
+
+import uk.gov.hmcts.reform.divorce.model.ccd.CoreCaseData;
+import uk.gov.hmcts.reform.divorce.model.usersession.DivorceSession;
+
+@Value
+public class DivorceCaseWrapper {
+    private CoreCaseData caseData;
+    private DivorceSession divorceSession;
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/model/ccd/DnCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/model/ccd/DnCaseData.java
@@ -88,8 +88,14 @@ public class DnCaseData {
     @JsonProperty("DesertionAskedToResumeDNDetails")
     private String desertionAskedToResumeDNDetails;
 
+    @JsonProperty("RefusalClarificationReason")
+    private List<String> refusalClarificationReason;
+
+    @JsonProperty("RefusalClarificationAdditionalInfo")
+    private String refusalClarificationAdditionalInfo;
+
     @JsonProperty("DnClarificationResponse")
-    private List<String> dnClarificationResponse;
+    private List<CollectionMember<String>> dnClarificationResponse;
 
     @JsonProperty("DocumentsUploadedDnClarification")
     private List<CollectionMember<Document>> documentsUploadedDnClarification;

--- a/src/main/java/uk/gov/hmcts/reform/divorce/model/ccd/DnCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/model/ccd/DnCaseData.java
@@ -87,4 +87,10 @@ public class DnCaseData {
 
     @JsonProperty("DesertionAskedToResumeDNDetails")
     private String desertionAskedToResumeDNDetails;
+
+    @JsonProperty("DnClarificationResponse")
+    private List<String> dnClarificationResponse;
+
+    @JsonProperty("DocumentsUploadedDnClarification")
+    private List<CollectionMember<Document>> documentsUploadedDnClarification;
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/model/usersession/DivorceSession.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/model/usersession/DivorceSession.java
@@ -517,6 +517,9 @@ public class DivorceSession {
         value = "Final date to apply for Decree Absolute.")
     private Date dateCaseNoLongerEligibleForDA;
 
+    @ApiModelProperty(value = "Clarification response for the current clarification journey")
+    private String clarificationResponse;
+
     public void setD8Documents(List<UploadedFile> d8Documents) {
         if (CollectionUtils.isNotEmpty(d8Documents)) {
             d8Documents.forEach(doc -> doc.setFileType("petition"));

--- a/src/main/java/uk/gov/hmcts/reform/divorce/model/usersession/DivorceSession.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/model/usersession/DivorceSession.java
@@ -517,6 +517,12 @@ public class DivorceSession {
         value = "Final date to apply for Decree Absolute.")
     private Date dateCaseNoLongerEligibleForDA;
 
+    @ApiModelProperty("Reason for why clarification is needed.")
+    private List<String> refusalClarificationReason;
+
+    @ApiModelProperty("Any additional input by the legal advisor.")
+    private String refusalClarificationAdditionalInfo;
+
     @ApiModelProperty(value = "Clarification response for the current clarification journey")
     private String clarificationResponse;
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/formatter/impl/CaseFormatterServiceImplUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/formatter/impl/CaseFormatterServiceImplUTest.java
@@ -203,6 +203,59 @@ public class CaseFormatterServiceImplUTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    public void givenMultipleGenericD8DocumentsExistsInCaseData_whenAddDocuments_thenAddDocuments() {
+        final String url1 = "url1";
+        final String documentType1 = "petition";
+        final String fileName1 = "fileName1";
+        final String url2 = "url2";
+        final String documentType2 = "aos";
+        final String fileName2 = "fileName2";
+
+        final String url3 = "url3";
+        final String documentType3 = "other";
+        final String fileName3 = "fileName3";
+
+        final String url4 = "url4";
+        final String documentType4 = "aos";
+        final String fileName4 = "fileName4";
+
+        final String url5 = "url5";
+        final String documentType5 = "other";
+        final String fileName5 = "fileName5";
+
+        final GeneratedDocumentInfo generatedDocumentInfo1 = createGeneratedDocument(url1, documentType1, fileName1);
+        final GeneratedDocumentInfo generatedDocumentInfo2 = createGeneratedDocument(url2, documentType2, fileName2);
+        final GeneratedDocumentInfo generatedDocumentInfo3 = createGeneratedDocument(url3, documentType3, fileName3);
+
+        final CollectionMember<Document> document1 = createCollectionMemberDocument(url1, documentType1, fileName1);
+        final CollectionMember<Document> document2 = createCollectionMemberDocument(url2, documentType2, fileName2);
+        final CollectionMember<Document> document3 = createCollectionMemberDocument(url3, documentType3, fileName3);
+        final CollectionMember<Document> document4 = createCollectionMemberDocument(url4, documentType4, fileName4);
+        final CollectionMember<Document> document5 = createCollectionMemberDocument(url5, documentType5, fileName5);
+
+        when(documentCollectionDocumentRequestMapper.map(generatedDocumentInfo1)).thenReturn(document1);
+        when(documentCollectionDocumentRequestMapper.map(generatedDocumentInfo2)).thenReturn(document2);
+        when(documentCollectionDocumentRequestMapper.map(generatedDocumentInfo3)).thenReturn(document3);
+
+        final Map<String, Object> expected =
+            Collections.singletonMap(D8_DOCUMENTS_GENERATED_CCD_FIELD,
+                Arrays.asList(document5, document1, document2, document3));
+
+        final Map<String, Object> input = new HashMap<>();
+        input.put(D8_DOCUMENTS_GENERATED_CCD_FIELD, Arrays.asList(document4, document5));
+
+        DocumentUpdateRequest documentUpdateRequest = new DocumentUpdateRequest();
+        documentUpdateRequest.setDocuments(
+            Arrays.asList(generatedDocumentInfo1, generatedDocumentInfo2, generatedDocumentInfo3));
+        documentUpdateRequest.setCaseData(input);
+
+        Map<String, Object> actual = classUnderTest.addDocuments(input,
+            Arrays.asList(generatedDocumentInfo1, generatedDocumentInfo2, generatedDocumentInfo3));
+
+        assertEquals(expected, actual);
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void givenCoreCaseDataIsNull_whenRemoveAllPetitions_thenReturnThrowException() {
         classUnderTest.removeAllPetitionDocuments(null);

--- a/src/test/java/uk/gov/hmcts/reform/divorce/formatter/mapper/ccdtodivorceformat/DecreeNisiClarificationMapperUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/formatter/mapper/ccdtodivorceformat/DecreeNisiClarificationMapperUTest.java
@@ -1,0 +1,49 @@
+package uk.gov.hmcts.reform.divorce.formatter.mapper.ccdtodivorceformat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.hmcts.reform.divorce.config.BeanConfig;
+import uk.gov.hmcts.reform.divorce.formatter.mapper.CCDCaseToDivorceMapper;
+import uk.gov.hmcts.reform.divorce.formatter.mapper.ObjectMapperTestUtil;
+import uk.gov.hmcts.reform.divorce.model.ccd.CoreCaseData;
+import uk.gov.hmcts.reform.divorce.model.usersession.DivorceSession;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.samePropertyValuesAs;
+
+@ContextConfiguration(classes = BeanConfig.class)
+@SpringBootTest
+@RunWith(SpringRunner.class)
+public class DecreeNisiClarificationMapperUTest {
+
+    @Autowired
+    private CCDCaseToDivorceMapper mapper;
+
+    @Test
+    public void shouldMapAllAndTransformAllFieldsForDecreeNisiOutcomeFieldsScenario()
+        throws URISyntaxException, IOException {
+
+        CoreCaseData coreCaseData = ObjectMapperTestUtil
+            .retrieveFileContentsAsObject(
+                "fixtures/ccdtodivorcemapping/ccd/dn-clarification.json",
+                CoreCaseData.class
+            );
+
+        DivorceSession expectedDivorceSession = ObjectMapperTestUtil
+            .retrieveFileContentsAsObject(
+                "fixtures/ccdtodivorcemapping/divorce/dn-clarification.json",
+                DivorceSession.class
+            );
+
+        DivorceSession actualDivorceSession = mapper.courtCaseDataToDivorceCaseData(coreCaseData);
+
+        assertThat(actualDivorceSession, samePropertyValuesAs(expectedDivorceSession));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/divorce/formatter/mapper/divorcetoccdformat/DivorceCaseToDnClarificationMapperUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/formatter/mapper/divorcetoccdformat/DivorceCaseToDnClarificationMapperUTest.java
@@ -70,7 +70,10 @@ public class DivorceCaseToDnClarificationMapperUTest {
         existingDocuments.add(collectionMember);
 
         CoreCaseData coreCaseData = new CoreCaseData();
-        coreCaseData.setDnClarificationResponse(new ArrayList<>(Arrays.asList("This is the initial response")));
+        CollectionMember<String> clarificationResponse = new CollectionMember<>();
+        clarificationResponse.setId("initial-id");
+        clarificationResponse.setValue("This is the initial response");
+        coreCaseData.setDnClarificationResponse(new ArrayList<>(Arrays.asList(clarificationResponse)));
         coreCaseData.setDocumentsUploadedDnClarification(existingDocuments);
 
         DnCaseData expectedDnCaseData = ObjectMapperTestUtil

--- a/src/test/java/uk/gov/hmcts/reform/divorce/formatter/mapper/divorcetoccdformat/DivorceCaseToDnClarificationMapperUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/formatter/mapper/divorcetoccdformat/DivorceCaseToDnClarificationMapperUTest.java
@@ -1,0 +1,90 @@
+package uk.gov.hmcts.reform.divorce.formatter.mapper.divorcetoccdformat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import uk.gov.hmcts.reform.divorce.config.BeanConfig;
+import uk.gov.hmcts.reform.divorce.formatter.mapper.DivorceCaseToDnClarificationMapper;
+import uk.gov.hmcts.reform.divorce.formatter.mapper.ObjectMapperTestUtil;
+import uk.gov.hmcts.reform.divorce.model.DivorceCaseWrapper;
+import uk.gov.hmcts.reform.divorce.model.ccd.CollectionMember;
+import uk.gov.hmcts.reform.divorce.model.ccd.CoreCaseData;
+import uk.gov.hmcts.reform.divorce.model.ccd.DnCaseData;
+import uk.gov.hmcts.reform.divorce.model.ccd.Document;
+import uk.gov.hmcts.reform.divorce.model.ccd.DocumentLink;
+import uk.gov.hmcts.reform.divorce.model.usersession.DivorceSession;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.samePropertyValuesAs;
+
+@ContextConfiguration(classes = BeanConfig.class)
+@SpringBootTest
+@RunWith(SpringRunner.class)
+public class DivorceCaseToDnClarificationMapperUTest {
+
+    @Autowired
+    private DivorceCaseToDnClarificationMapper mapper;
+
+    @Test
+    public void shouldMapDivorceSessionFieldsToDnCaseData() throws Exception {
+        CoreCaseData coreCaseData = new CoreCaseData();
+
+        DnCaseData expectedDnCaseData = ObjectMapperTestUtil
+            .retrieveFileContentsAsObject("fixtures/divorcetoccdmapping/ccd/dn-clarification.json", DnCaseData.class);
+
+        DivorceSession divorceSession = ObjectMapperTestUtil
+            .retrieveFileContentsAsObject("fixtures/divorcetoccdmapping/divorce/dn-clarification.json",
+                DivorceSession.class);
+
+        DivorceCaseWrapper divorceCaseWrapper = new DivorceCaseWrapper(coreCaseData, divorceSession);
+
+        DnCaseData actualDnCaseData = mapper.divorceCaseDataToDnCaseData(divorceCaseWrapper);
+
+        assertThat(actualDnCaseData, samePropertyValuesAs(expectedDnCaseData));
+    }
+
+    @Test
+    public void shouldMapDivorceSessionFieldsToDnCaseDataWithExistingData() throws Exception {
+        Document existingDocument = new Document();
+        existingDocument.setDocumentType("other");
+        existingDocument.setDocumentDateAdded("2011-11-11");
+        existingDocument.setDocumentComment("");
+        existingDocument.setDocumentFileName("favicon.ico");
+        existingDocument.setDocumentEmailContent("");
+        DocumentLink documentLink = new DocumentLink();
+        documentLink.setDocumentUrl("http://localhost:5006/documents/1234567-abcd-1234-wxyz-098765432101");
+        existingDocument.setDocumentLink(documentLink);
+
+        CollectionMember<Document> collectionMember = new CollectionMember<>();
+        collectionMember.setValue(existingDocument);
+
+        List<CollectionMember<Document>> existingDocuments = new ArrayList<>();
+        existingDocuments.add(collectionMember);
+
+        CoreCaseData coreCaseData = new CoreCaseData();
+        coreCaseData.setDnClarificationResponse(new ArrayList<>(Arrays.asList("This is the initial response")));
+        coreCaseData.setDocumentsUploadedDnClarification(existingDocuments);
+
+        DnCaseData expectedDnCaseData = ObjectMapperTestUtil
+            .retrieveFileContentsAsObject("fixtures/divorcetoccdmapping/ccd/dn-clarification-existing-data.json",
+                DnCaseData.class);
+
+        DivorceSession divorceSession = ObjectMapperTestUtil
+            .retrieveFileContentsAsObject("fixtures/divorcetoccdmapping/divorce/dn-clarification-existing-data.json",
+                DivorceSession.class);
+
+        DivorceCaseWrapper divorceCaseWrapper = new DivorceCaseWrapper(coreCaseData, divorceSession);
+
+        DnCaseData actualDnCaseData = mapper.divorceCaseDataToDnCaseData(divorceCaseWrapper);
+
+        assertThat(actualDnCaseData, samePropertyValuesAs(expectedDnCaseData));
+    }
+}

--- a/src/test/resources/fixtures/ccdtodivorcemapping/ccd/dn-clarification.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/ccd/dn-clarification.json
@@ -1,0 +1,7 @@
+{
+  "RefusalClarificationReason": [
+    "noJurisdiction",
+    "other"
+  ],
+  "RefusalClarificationAdditionalInfo": "The petitioner needs to provide more information."
+}

--- a/src/test/resources/fixtures/ccdtodivorcemapping/divorce/dn-clarification.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/divorce/dn-clarification.json
@@ -1,0 +1,61 @@
+{
+  "refusalClarificationReason": [
+    "noJurisdiction",
+    "other"
+  ],
+  "refusalClarificationAdditionalInfo": "The petitioner needs to provide more information.",
+  "court": {
+    "eastMidlands": {
+      "divorceCentre": "East Midlands Regional Divorce Centre",
+      "courtCity": "Nottingham",
+      "poBox": "PO Box 10447",
+      "postCode": "NG2 9QN",
+      "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
+      "email": "eastmidlandsdivorce@hmcts.gsi.gov.uk",
+      "phoneNumber": "0300 303 0642",
+      "siteId": "AA01"
+    },
+    "westMidlands": {
+      "divorceCentre": "West Midlands Regional Divorce Centre",
+      "courtCity": "Stoke-on-Trent",
+      "poBox": "PO Box 3650",
+      "postCode": "ST4 9NH",
+      "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
+      "email": "westmidlandsdivorce@hmcts.gsi.gov.uk",
+      "phoneNumber": "0300 303 0642",
+      "siteId": "AA02"
+    },
+    "southWest": {
+      "divorceCentre": "South West Regional Divorce Centre",
+      "courtCity": "Southampton",
+      "poBox": "PO Box 1792",
+      "postCode": "SO15 9GG",
+      "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
+      "email": "sw-region-divorce@hmcts.gsi.gov.uk",
+      "phoneNumber": "0300 303 0642",
+      "siteId": "AA03"
+    },
+    "northWest": {
+      "divorceCentre": "North West Regional Divorce Centre",
+      "divorceCentreAddressName": "Liverpool Civil & Family Court",
+      "courtCity": "Liverpool",
+      "street": "35 Vernon Street",
+      "postCode": "L2 2BX",
+      "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
+      "email": "family@liverpool.countycourt.gsi.gov.uk",
+      "phoneNumber": "0300 303 0642",
+      "siteId": "AA04"
+    },
+    "serviceCentre": {
+      "serviceCentreName": "Courts and Tribunals Service Centre",
+      "divorceCentre": "HMCTS Digital Divorce",
+      "courtCity": "Harlow",
+      "poBox": "PO Box 12706",
+      "postCode": "CM20 9QT",
+      "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
+      "email": "divorcecase@justice.gov.uk",
+      "phoneNumber": "0300 303 0642",
+      "siteId": "AA07"
+    }
+  }
+}

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/dn-clarification-existing-data.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/dn-clarification-existing-data.json
@@ -1,7 +1,13 @@
 {
   "DnClarificationResponse" : [
-    "This is the initial response",
-    "This is a response attempt."
+    {
+      "id" : "initial-id",
+      "value" : "This is the initial response"
+    },
+    {
+      "id" : null,
+      "value" : "This is a response attempt."
+    }
   ],
   "DocumentsUploadedDnClarification" : [
     {

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/dn-clarification-existing-data.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/dn-clarification-existing-data.json
@@ -1,0 +1,53 @@
+{
+  "DnClarificationResponse" : [
+    "This is the initial response",
+    "This is a response attempt."
+  ],
+  "DocumentsUploadedDnClarification" : [
+    {
+      "id" : null,
+      "value" : {
+        "DocumentType" : "other",
+        "DocumentLink" : {
+          "document_url" : "http://localhost:5006/documents/1234567-abcd-1234-wxyz-098765432101",
+          "document_binary_url" : null,
+          "document_filename" : null
+        },
+        "DocumentDateAdded" : "2011-11-11",
+        "DocumentComment" : "",
+        "DocumentFileName" : "favicon.ico",
+        "DocumentEmailContent" : ""
+      }
+    },
+    {
+      "id" : null,
+      "value" : {
+        "DocumentType" : "other",
+        "DocumentLink" : {
+          "document_url" : "http://localhost:5006/documents/7f63ca9b-c361-49ab-aa8c-8fbdb6bc2936",
+          "document_binary_url" : null,
+          "document_filename" : null
+        },
+        "DocumentDateAdded" : "2017-12-11",
+        "DocumentComment" : "",
+        "DocumentFileName" : "govuklogo.png",
+        "DocumentEmailContent" : ""
+      }
+    },
+    {
+      "id" : null,
+      "value" : {
+        "DocumentType": "other",
+        "DocumentLink" : {
+          "document_url" : "http://localhost:5006/documents/560f4bd1-fcf2-4dc5-80d1-d7e00d861655",
+          "document_binary_url" : null,
+          "document_filename" : null
+        },
+        "DocumentDateAdded": "2017-12-11",
+        "DocumentComment": "",
+        "DocumentFileName": "d8-eng.pdf",
+        "DocumentEmailContent": ""
+      }
+    }
+  ]
+}

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/dn-clarification.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/dn-clarification.json
@@ -1,0 +1,37 @@
+{
+  "DnClarificationResponse" : [
+    "This is a response attempt."
+  ],
+  "DocumentsUploadedDnClarification" : [
+    {
+      "id" : null,
+      "value" : {
+        "DocumentType" : "other",
+        "DocumentLink" : {
+          "document_url" : "http://localhost:5006/documents/7f63ca9b-c361-49ab-aa8c-8fbdb6bc2936",
+          "document_binary_url" : null,
+          "document_filename" : null
+        },
+        "DocumentDateAdded" : "2017-12-11",
+        "DocumentComment" : "",
+        "DocumentFileName" : "govuklogo.png",
+        "DocumentEmailContent" : ""
+      }
+    },
+    {
+      "id" : null,
+      "value" : {
+        "DocumentType": "other",
+        "DocumentLink" : {
+          "document_url" : "http://localhost:5006/documents/560f4bd1-fcf2-4dc5-80d1-d7e00d861655",
+          "document_binary_url" : null,
+          "document_filename" : null
+        },
+        "DocumentDateAdded": "2017-12-11",
+        "DocumentComment": "",
+        "DocumentFileName": "d8-eng.pdf",
+        "DocumentEmailContent": ""
+      }
+    }
+  ]
+}

--- a/src/test/resources/fixtures/divorcetoccdmapping/ccd/dn-clarification.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/ccd/dn-clarification.json
@@ -1,6 +1,9 @@
 {
   "DnClarificationResponse" : [
-    "This is a response attempt."
+    {
+      "id" : null,
+      "value" : "This is a response attempt."
+    }
   ],
   "DocumentsUploadedDnClarification" : [
     {

--- a/src/test/resources/fixtures/divorcetoccdmapping/divorce/dn-clarification-existing-data.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/divorce/dn-clarification-existing-data.json
@@ -1,0 +1,25 @@
+{
+  "clarificationResponse": "This is a response attempt.",
+  "files" : [
+    {
+      "createdBy" : 12661,
+      "createdOn" : "2017-12-11",
+      "lastModifiedBy" : 12661,
+      "modifiedOn" : "2017-12-11",
+      "fileName" : "govuklogo.png",
+      "fileUrl" : "http://localhost:5006/documents/7f63ca9b-c361-49ab-aa8c-8fbdb6bc2936",
+      "mimeType" : "image/png",
+      "status" : "OK"
+    },
+    {
+      "createdBy" : 12661,
+      "createdOn" : "2017-12-11",
+      "lastModifiedBy" : 12661,
+      "modifiedOn" : "2017-12-11",
+      "fileName" : "d8-eng.pdf",
+      "fileUrl" : "http://localhost:5006/documents/560f4bd1-fcf2-4dc5-80d1-d7e00d861655",
+      "mimeType" : "application/pdf",
+      "status" : "OK"
+    }
+  ]
+}

--- a/src/test/resources/fixtures/divorcetoccdmapping/divorce/dn-clarification.json
+++ b/src/test/resources/fixtures/divorcetoccdmapping/divorce/dn-clarification.json
@@ -1,0 +1,25 @@
+{
+  "clarificationResponse": "This is a response attempt.",
+  "files" : [
+    {
+      "createdBy" : 12661,
+      "createdOn" : "2017-12-11",
+      "lastModifiedBy" : 12661,
+      "modifiedOn" : "2017-12-11",
+      "fileName" : "govuklogo.png",
+      "fileUrl" : "http://localhost:5006/documents/7f63ca9b-c361-49ab-aa8c-8fbdb6bc2936",
+      "mimeType" : "image/png",
+      "status" : "OK"
+    },
+    {
+      "createdBy" : 12661,
+      "createdOn" : "2017-12-11",
+      "lastModifiedBy" : 12661,
+      "modifiedOn" : "2017-12-11",
+      "fileName" : "d8-eng.pdf",
+      "fileUrl" : "http://localhost:5006/documents/560f4bd1-fcf2-4dc5-80d1-d7e00d861655",
+      "mimeType" : "application/pdf",
+      "status" : "OK"
+    }
+  ]
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

Required for:

https://tools.hmcts.net/jira/browse/DIV-5766

### Change description ###

This PR allows Decree Nisi Clarification Submission fields to be mapped from frontend format to CCD format.
The two new fields introduced are `DnClarificationResponse` for the Petitioner's response to the clarification request, and `DocumentsUploadedDnClarification` for any additional documents uploaded as part of clarification evidence.

On DivorceSession side, the `files` key is re-used for documents uploaded, and a new `clarificationResponse` field will be sent from frontend to be mapped to `DnClarificationResponse` on CCD. Note that because there can be multiple clarifications, the frontend will send one clarificationResponse at a time, and on the mapper we will always append to the existing list of clarificationResponses. Similarly to documents, however frontend will pass an array and we will simply add everything in the array to the existing documents list.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
