### PR TITLE
DIV-6348: formatDateForDocuments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '1.1.16'
+version '1.1.17'
 
 dependencyUpdates.resolutionStrategy = {
     componentSelection { rules ->

--- a/src/main/java/uk/gov/hmcts/reform/divorce/utils/DateUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/utils/DateUtils.java
@@ -18,10 +18,13 @@ import java.util.TimeZone;
 
 @Slf4j
 public class DateUtils {
+    public static final String DEFAULT_FORMATTING = "yyyy-MM-dd";
+    public static final String TIME_FORMAT = "HH:mm";
 
     private static final DateTimeFormatter CLIENT_FACING_DATE_FORMAT = DateTimeFormatter
         .ofLocalizedDate(FormatStyle.LONG)
         .withLocale(Locale.UK);
+    public static final String DATE_FORMAT_FOR_DOCUMENTS = "dd MMM yyyy";
 
     private DateUtils() {
         // utility class
@@ -30,7 +33,7 @@ public class DateUtils {
     public static Instant parseToInstant(String date) {
         Instant instant = null;
         try {
-            SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault());
+            SimpleDateFormat simpleDateFormat = new SimpleDateFormat(DEFAULT_FORMATTING, Locale.getDefault());
             simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
             instant = simpleDateFormat
                 .parse(date)
@@ -58,9 +61,20 @@ public class DateUtils {
         return date.format(CLIENT_FACING_DATE_FORMAT);
     }
 
-    public static String formatDateFromLocalDate(LocalDate date) {
+    public static String formatDateForDocuments(String date) {
+        return formatDateForDocuments(
+            parseToInstant(date)
+                .atZone(ZoneId.systemDefault())
+                .toLocalDate()
+        );
+    }
 
-        return date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+    public static String formatDateForDocuments(LocalDate date) {
+        return date.format(DateTimeFormatter.ofPattern(DATE_FORMAT_FOR_DOCUMENTS, Locale.UK));
+    }
+
+    public static String formatDateFromLocalDate(LocalDate date) {
+        return date.format(DateTimeFormatter.ofPattern(DEFAULT_FORMATTING, Locale.UK));
     }
 
     public static String formatDateFromDateTime(LocalDateTime dateTime) {
@@ -68,7 +82,7 @@ public class DateUtils {
     }
 
     public static String formatTimeFromDateTime(LocalDateTime dateTime) {
-        return dateTime.toLocalTime().format(DateTimeFormatter.ofPattern("HH:mm"));
+        return dateTime.toLocalTime().format(DateTimeFormatter.ofPattern(TIME_FORMAT));
     }
 
     public static String formatNullableDate(Date date, String pattern) {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/utils/DateUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/utils/DateUtilsTest.java
@@ -7,13 +7,18 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.Month;
 import java.time.ZoneOffset;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static uk.gov.hmcts.reform.divorce.utils.DateUtils.formatDateForDocuments;
+import static uk.gov.hmcts.reform.divorce.utils.DateUtils.formatDateWithCustomerFacingFormat;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 public class DateUtilsTest {
@@ -113,5 +118,27 @@ public class DateUtilsTest {
         String dateString = DateUtils.formatNullableDate(date, "YYYY");
 
         assertEquals(expectedDateString, dateString);
+    }
+
+    @Test
+    public void formatDateWithCustomerFacingFormatReturnsFormattedDateString() {
+        assertThat(
+            formatDateWithCustomerFacingFormat(LocalDate.of(2020, Month.JUNE, 4)),
+            is("4 June 2020")
+        );
+    }
+
+    @Test
+    public void formatDateForDocumentsReturnsFormattedDateStringLeadingZerosForDay() {
+        assertThat(
+            formatDateForDocuments(LocalDate.of(2020, Month.JUNE, 4)),
+            is("04 Jun 2020")
+        );
+        assertThat(formatDateForDocuments("2020-06-04"), is("04 Jun 2020"));
+        assertThat(
+                formatDateForDocuments(LocalDate.of(1999, Month.OCTOBER, 20)),
+                is("20 Oct 1999")
+        );
+        assertThat(formatDateForDocuments("1999-10-20"), is("20 Oct 1999"));
     }
 }


### PR DESCRIPTION
Dates for all docmosis documents should be:

dd MMM yyyy,

eg
10 Nov 2010
04 May 1999

https://tools.hmcts.net/jira/browse/DIV-6348