### PR TITLE
New date time format for documents

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '1.1.28'
+version '1.1.29'
 
 dependencyUpdates.resolutionStrategy = {
     componentSelection { rules ->

--- a/src/main/java/uk/gov/hmcts/reform/divorce/utils/DateUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/utils/DateUtils.java
@@ -32,6 +32,10 @@ public class DateUtils {
          Format of dates to display to user, eg. 7 July 1999
          */
         public static final String CLIENT_FACING_DATE = "d MMMM yyyy";
+        /*
+         Format of datetime expected for document names that can be generated multiple times
+         */
+        public static final String DOCUMENT_DATE_TIME = "yyyy-MM-dd'T'HH:mm:ss";
     }
 
     public static class Settings {
@@ -45,6 +49,7 @@ public class DateUtils {
         public static DateTimeFormatter CCD_DATE = getFormatter(Formats.CCD_DATE);
         public static DateTimeFormatter CCD_DATE_TIME = getFormatter(Formats.CCD_DATE_TIME);
         public static DateTimeFormatter CLIENT_FACING = getFormatter(Formats.CLIENT_FACING_DATE);
+        public static DateTimeFormatter DOCUMENT_DATE_TIME = getFormatter(Formats.DOCUMENT_DATE_TIME);
     }
 
     private DateUtils() {
@@ -92,6 +97,10 @@ public class DateUtils {
 
     public static String formatDateTimeForCcd(LocalDateTime dateTime) {
         return dateTime.format(Formatters.CCD_DATE_TIME);
+    }
+
+    public static String formatDateTimeForDocument(LocalDateTime dateTime) {
+        return dateTime.format(Formatters.DOCUMENT_DATE_TIME);
     }
 
     public static String formatDateFromLocalDate(LocalDate date) {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/utils/DateUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/utils/DateUtilsTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static uk.gov.hmcts.reform.divorce.utils.DateUtils.formatDateTimeForCcd;
+import static uk.gov.hmcts.reform.divorce.utils.DateUtils.formatDateTimeForDocument;
 import static uk.gov.hmcts.reform.divorce.utils.DateUtils.formatDateWithCustomerFacingFormat;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -143,6 +144,38 @@ public class DateUtilsTest {
         assertThat(
             formatDateTimeForCcd(LocalDateTime.of(2020, Month.JUNE, 4, 2, 1, 5)),
             is("2020-06-04T02:01:05.000")
+        );
+    }
+
+    @Test
+    public void formatDateTimeForDocumentReturnsValidString() {
+        assertThat(
+                formatDateTimeForDocument(LocalDateTime.of(2020, Month.OCTOBER, 14, 2, 1, 5)),
+                is("2020-10-14T02:01:05")
+        );
+    }
+
+    @Test
+    public void givenDateBeforeYear2000_whenformatDateTimeForDocument_thenReturnsValidString() {
+        assertThat(
+                formatDateTimeForDocument(LocalDateTime.of(1999, Month.MAY, 1, 2, 1, 5)),
+                is("1999-05-01T02:01:05")
+        );
+    }
+
+    @Test
+    public void givenYearWith3Digits_whenformatDateTimeForDocument_thenReturnsValidString() {
+        assertThat(
+                formatDateTimeForDocument(LocalDateTime.of(345, Month.OCTOBER, 20, 2, 1, 5)),
+                is("0345-10-20T02:01:05")
+        );
+    }
+
+    @Test
+    public void givenAfternoonTime_whenformatDateTimeForDocument_thenReturnsValidString() {
+        assertThat(
+                formatDateTimeForDocument(LocalDateTime.of(2020, Month.OCTOBER, 14, 13, 1, 5)),
+                is("2020-10-14T13:01:05")
         );
     }
 }


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DIV-6596

### Change description ###

New date time format for documents.
When only using date, documents generated the same day get the same name.
This causes frontends to display only 1 of those documents multiple times rather than each as appropriate.
Can not use CCD-datetime format as it breaks the test (too precise).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
