### PR TITLE
DIV-5463: Adding CCD to divorce mapping for fields: successfulServedByBailiff and reasonFailureToServe

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '1.2.11'
+version '1.2.12'
 
 sourceCompatibility = 11
 targetCompatibility = 11

--- a/src/main/java/uk/gov/hmcts/reform/divorce/mapper/CCDCaseToDivorceMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/mapper/CCDCaseToDivorceMapper.java
@@ -178,6 +178,8 @@ public abstract class CCDCaseToDivorceMapper {
     @Mapping(source = "coRespondentPcqId", target = "coRespondentPcqId")
     @Mapping(source = "d8ReasonForDivorceBehaviourDetailsTrans", target = "reasonForDivorceBehaviourDetailsTrans")
     @Mapping(source = "d8ReasonForDivorceBehaviourDetailsTransLang", target = "reasonForDivorceBehaviourDetailsTransLang")
+    @Mapping(source = "successfulServedByBailiff", target = "successfulServedByBailiff")
+    @Mapping(source = "reasonFailureToServe", target = "reasonFailureToServe")
     public abstract DivorceSession coreCaseDataToDivorceCaseData(CoreCaseData coreCaseData);
 
     private String translateToBooleanString(final String value) {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/model/ccd/CoreCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/model/ccd/CoreCaseData.java
@@ -642,4 +642,10 @@ public class CoreCaseData extends AosCaseData {
     @JsonProperty("RespondentOrganisationPolicy")
     private OrganisationPolicy respondentOrganisationPolicy;
 
+    @JsonProperty("SuccessfulServedByBailiff")
+    private String successfulServedByBailiff;
+
+    @JsonProperty("ReasonFailureToServe")
+    private String reasonFailureToServe;
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/model/usersession/DivorceSession.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/model/usersession/DivorceSession.java
@@ -656,6 +656,12 @@ public class DivorceSession {
     @ApiModelProperty(value = "Is the language preference Welsh?", allowableValues = "Yes, No")
     private String languagePreferenceWelsh;
 
+    @ApiModelProperty(value = "Indicates if the bailiff service was successful")
+    private String successfulServedByBailiff;
+
+    @ApiModelProperty(value = "Indicates the reason for failure to serve the bailiff service")
+    private String reasonFailureToServe;
+
     public void setD8Documents(List<UploadedFile> d8Documents) {
         if (CollectionUtils.isNotEmpty(d8Documents)) {
             d8Documents.forEach(doc -> doc.setFileType("petition"));

--- a/src/test/java/uk/gov/hmcts/reform/divorce/mapper/ccdtodivorceformat/BailiffServiceNotSuccessfulToDivorceMapperUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/mapper/ccdtodivorceformat/BailiffServiceNotSuccessfulToDivorceMapperUTest.java
@@ -1,0 +1,43 @@
+package uk.gov.hmcts.reform.divorce.mapper.ccdtodivorceformat;
+
+import org.hamcrest.beans.SamePropertyValuesAs;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.hmcts.reform.divorce.config.MappingConfig;
+import uk.gov.hmcts.reform.divorce.mapper.CCDCaseToDivorceMapper;
+import uk.gov.hmcts.reform.divorce.model.ccd.CoreCaseData;
+import uk.gov.hmcts.reform.divorce.model.usersession.DivorceSession;
+import uk.gov.hmcts.reform.divorce.utils.ObjectMapperTestUtil;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = {MappingConfig.class})
+public class BailiffServiceNotSuccessfulToDivorceMapperUTest {
+
+    @Autowired
+    private CCDCaseToDivorceMapper mapper;
+
+    @Test
+    public void shouldMapAllAndTransformAllFields()
+        throws URISyntaxException, IOException {
+
+        CoreCaseData caseData = ObjectMapperTestUtil
+            .retrieveFileContentsAsObject("fixtures/ccdtodivorcemapping/ccd/bailiff-service-not-successful.json",
+                CoreCaseData.class);
+
+        DivorceSession expectedDivorceSession = ObjectMapperTestUtil.retrieveFileContentsAsObject(
+            "fixtures/ccdtodivorcemapping/divorce/bailiff-service-not-successful.json",
+            DivorceSession.class);
+
+        DivorceSession actualDivorceSession = mapper.coreCaseDataToDivorceCaseData(caseData);
+
+        assertThat(actualDivorceSession, SamePropertyValuesAs.samePropertyValuesAs(expectedDivorceSession));
+    }
+}

--- a/src/test/resources/fixtures/ccdtodivorcemapping/ccd/bailiff-service-not-successful.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/ccd/bailiff-service-not-successful.json
@@ -1,0 +1,4 @@
+{
+  "SuccessfulServedByBailiff": "NO",
+  "ReasonFailureToServe": "Test reason for failure to serve bailiff"
+}

--- a/src/test/resources/fixtures/ccdtodivorcemapping/divorce/bailiff-service-not-successful.json
+++ b/src/test/resources/fixtures/ccdtodivorcemapping/divorce/bailiff-service-not-successful.json
@@ -1,0 +1,4 @@
+{
+  "successfulServedByBailiff": "NO",
+  "reasonFailureToServe": "Test reason for failure to serve bailiff"
+}


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DIV-5463

### Change description ###

Adding CCD to divorce mapping for fields: successfulServedByBailiff and reasonFailureToServe

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
